### PR TITLE
Oracle Support - Update handler-delete to be database agnostic and mockito upgrade

### DIFF
--- a/codjo-referential-datagen/src/datagen/DatagenTest.xml
+++ b/codjo-referential-datagen/src/datagen/DatagenTest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 
 <entities>
-    <entity name="net.codjo.referential.ref.Country" table="REF_COUNTRY">
+    <entity name="net.codjo.referential.ref.Country" table="REF_COUNTRY" order-clause="refCode">
         <description>Pays</description>
 
         <feature>

--- a/codjo-referential-datagen/src/datagen/datagen.xml
+++ b/codjo-referential-datagen/src/datagen/datagen.xml
@@ -14,14 +14,6 @@
             <handler-update id="update${className}"/>
             <handler-new id="new${className}"/>
             <handler-select id="select${className}ById" type="By_Primary-Key"/>
-            <handler-sql id="delete${className}" transaction="true">
-                <query>
-                    delete from PM_REF_FAMILY_REF_ASSO where FAMILY_ID = ?
-                    delete from PM_REFERENTIAL_FAMILY where FAMILY_ID = ?
-                </query>
-                <arg>familyId</arg>
-                <arg>familyId</arg>
-            </handler-sql>
             <handler-select id="selectAll${className}">
                 <query><![CDATA[
                      select FAMILY_ID, FAMILY_LABEL

--- a/codjo-referential-datagen/src/datagen/datagen.xml
+++ b/codjo-referential-datagen/src/datagen/datagen.xml
@@ -15,15 +15,10 @@
             <handler-new id="new${className}"/>
             <handler-select id="select${className}ById" type="By_Primary-Key"/>
             <handler-sql id="delete${className}" transaction="true">
-                <attributes>
-                    <name>nbLines</name>
-                </attributes>
-                <query><![CDATA[
+                <query>
                     delete from PM_REF_FAMILY_REF_ASSO where FAMILY_ID = ?
                     delete from PM_REFERENTIAL_FAMILY where FAMILY_ID = ?
-                    
-                    select @@rowcount as NB_LINES
-                ]]></query>
+                </query>
                 <arg>familyId</arg>
                 <arg>familyId</arg>
             </handler-sql>

--- a/codjo-referential-gui-addon/src/test/resources/net/codjo/referential/gui/addon/dependencyTest.txt
+++ b/codjo-referential-gui-addon/src/test/resources/net/codjo/referential/gui/addon/dependencyTest.txt
@@ -26,7 +26,7 @@ net.codjo.referential.gui.addon.tabbed.customiser
 	-> net.codjo.security.common.api
 	-> net.codjo.test.common.matcher
 	-> org.mockito
-	-> org.mockito.internal.progress
+	-> org.mockito.stubbing
 	-> org.uispec4j
 	-> org.uispec4j.finder
 net.codjo.referential.gui.addon.tabbed.field
@@ -34,7 +34,7 @@ net.codjo.referential.gui.addon.tabbed.field
 	-> net.codjo.referential.gui.api
 	-> net.codjo.test.common.matcher
 	-> org.mockito
-	-> org.mockito.internal.progress
+	-> org.mockito.stubbing
 net.codjo.referential.gui.addon.tabbed.util
 	-> net.codjo.mad.client.request
 	-> net.codjo.mad.gui.framework
@@ -44,7 +44,7 @@ net.codjo.referential.gui.addon.tabbed.util
 	-> net.codjo.referential.gui.api
 	-> net.codjo.test.common.matcher
 	-> org.mockito
-	-> org.mockito.internal.progress
+	-> org.mockito.stubbing
 net.codjo.referential.gui.api
 	-> net.codjo.gui.toolkit.date
 	-> net.codjo.test.common.matcher

--- a/codjo-referential-gui/pom.xml
+++ b/codjo-referential-gui/pom.xml
@@ -72,11 +72,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>uispec4j</groupId>
-            <artifactId>uispec4j</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito</artifactId>
             <scope>test</scope>

--- a/codjo-referential-gui/src/main/resources/net/codjo/referential/gui/plugin/preferences.xml
+++ b/codjo-referential-gui/src/main/resources/net/codjo/referential/gui/plugin/preferences.xml
@@ -5,7 +5,7 @@
         <selectByPk>selectPmReferentialFamilyById</selectByPk>
         <selectAll>selectAllPmReferentialFamily</selectAll>
         <update>updatePmReferentialFamily</update>
-        <delete>deletePmReferentialFamily</delete>
+        <delete type="command">deletePmReferentialFamily</delete>
         <insert>newPmReferentialFamily</insert>
 
         <hidden>

--- a/codjo-referential-gui/src/test/resources/net/codjo/referential/gui/dependencyTest.txt
+++ b/codjo-referential-gui/src/test/resources/net/codjo/referential/gui/dependencyTest.txt
@@ -24,7 +24,7 @@ net.codjo.referential.gui.api
 	-> net.codjo.test.common
 	-> net.codjo.test.common.matcher
 	-> org.mockito
-	-> org.mockito.internal.progress
+	-> org.mockito.stubbing
 	-> org.uispec4j
 
 net.codjo.referential.gui.plugin

--- a/codjo-referential-release-test/pom.xml
+++ b/codjo-referential-release-test/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <!-- POM's layout - http://www.javaworld.com/javaworld/jw-05-2006/jw-0529-maven.html -->
 
     <modelVersion>4.0.0</modelVersion>
@@ -37,6 +38,11 @@
             <groupId>net.codjo.database</groupId>
             <artifactId>codjo-database-${databaseType}-api</artifactId>
             <optional>true</optional>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.codjo.referential</groupId>
+            <artifactId>codjo-referential-server</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/codjo-referential-release-test/src/config/server-config.properties
+++ b/codjo-referential-release-test/src/config/server-config.properties
@@ -20,9 +20,10 @@ platform-id=agf-referential-mock
 # Configuration Service JDBC ( net.codjo.agent.jdbc.JdbcService )
 # -----------------------------------------------------------------------------
 
-JDBCService.driver  =com.sybase.jdbc2.jdbc.SybDriver
-JDBCService.url     =jdbc:sybase:Tds:@databaseServer@:@databasePort@
+JDBCService.driver  =${databaseDriver}
+JDBCService.url     =@databaseJdbcUrl@
 JDBCService.catalog =@databaseCatalog@
+JDBCService.engine  =${databaseType}
 
 # -----------------------------------------------------------------------------
 # Configuration plugin security

--- a/codjo-referential-release-test/src/test/java/net/codjo/referential/releasetest/GuiPluginTestCase.java
+++ b/codjo-referential-release-test/src/test/java/net/codjo/referential/releasetest/GuiPluginTestCase.java
@@ -1,4 +1,9 @@
 package net.codjo.referential.releasetest;
+import java.awt.Dimension;
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.Properties;
 import net.codjo.agent.UserId;
 import net.codjo.agent.test.AgentContainerFixture;
 import net.codjo.database.common.api.JdbcFixture;
@@ -26,12 +31,9 @@ import net.codjo.security.common.api.UserMock;
 import net.codjo.security.gui.plugin.SecurityGuiPlugin;
 import net.codjo.security.server.plugin.SecurityServerPlugin;
 import net.codjo.sql.server.plugin.JdbcServerPlugin;
+import net.codjo.test.common.PathUtil;
 import net.codjo.test.common.fixture.CompositeFixture;
 import net.codjo.tokio.TokioFixture;
-import java.awt.Dimension;
-import java.io.IOException;
-import java.net.URL;
-import java.util.Properties;
 import org.uispec4j.Trigger;
 import org.uispec4j.UISpecTestCase;
 import org.uispec4j.Window;
@@ -89,7 +91,8 @@ public abstract class GuiPluginTestCase extends UISpecTestCase {
         serverCore.addPlugin(MadServerPlugin.class);
         serverCore.addPlugin(ServerTestPlugin.class);
         addPlugins(serverCore, getServerPlugins());
-        String configFile = getClass().getResource("/server-config.properties").getFile();
+        String configFile =
+              new File(PathUtil.findTargetDirectory(getClass()), "/config/server-config.properties").getCanonicalPath();
         String[] arguments = new String[]{"-configuration", configFile};
         serverCore.start(new CommandLineArguments(arguments));
     }

--- a/codjo-referential-release-test/src/test/java/net/codjo/referential/releasetest/ReferentialFamilyTest.java
+++ b/codjo-referential-release-test/src/test/java/net/codjo/referential/releasetest/ReferentialFamilyTest.java
@@ -1,10 +1,10 @@
 package net.codjo.referential.releasetest;
 import org.uispec4j.Button;
+import org.uispec4j.MenuBar;
+import org.uispec4j.MenuItem;
 import org.uispec4j.Table;
 import org.uispec4j.TextBox;
 import org.uispec4j.Window;
-import org.uispec4j.MenuBar;
-import org.uispec4j.MenuItem;
 import org.uispec4j.interception.WindowInterceptor;
 /**
  *

--- a/codjo-referential-release-test/src/test/java/net/codjo/referential/releasetest/ReferentialGuiTestCase.java
+++ b/codjo-referential-release-test/src/test/java/net/codjo/referential/releasetest/ReferentialGuiTestCase.java
@@ -1,9 +1,10 @@
 package net.codjo.referential.releasetest;
+import java.io.File;
 import net.codjo.mad.gui.base.GuiPlugin;
 import net.codjo.plugin.server.ServerPlugin;
 import net.codjo.referential.gui.plugin.ReferentialGuiPlugin;
-import java.io.File;
 import org.uispec4j.Window;
+import server.plugin.ReferentialServerPlugin;
 /**
  *
  */
@@ -18,7 +19,7 @@ public abstract class ReferentialGuiTestCase extends GuiPluginTestCase {
     @Override
     protected Class<? extends ServerPlugin>[] getServerPlugins() {
         //noinspection unchecked
-        return new Class[0];
+        return new Class[]{ReferentialServerPlugin.class};
     }
 
 

--- a/codjo-referential-release-test/src/test/java/net/codjo/referential/releasetest/ReferentialTest.java
+++ b/codjo-referential-release-test/src/test/java/net/codjo/referential/releasetest/ReferentialTest.java
@@ -129,7 +129,7 @@ public class ReferentialTest extends ReferentialGuiTestCase {
               .setLabel("Label1")
               .assertValidateButtonIsEnabled(true)
               .clickIsValid()
-              .setPib(123)
+              .setPib(123.01)
               .setPeople(456)
               .setValue(8.97)
               .setCloseDate("01", "01", "2007")

--- a/codjo-referential-release-test/src/test/resources/net/codjo/referential/releasetest/ReferentialTest.tokio
+++ b/codjo-referential-release-test/src/test/resources/net/codjo/referential/releasetest/ReferentialTest.tokio
@@ -107,6 +107,9 @@
             </table>
         </input>
         <etalon>
+            <comparators>
+                <comparator field="PIB" precision="0.00001"/>
+            </comparators>
             <table name="REF_CURRENCY" orderClause="REF_CODE,REF_LABEL">
                 <row>
                     <field name="REF_CODE" value="Code1"/>
@@ -138,6 +141,9 @@
             </table>
         </input>
         <etalon>
+            <comparators>
+                <comparator field="PIB" precision="0.00001"/>
+            </comparators>
             <table name="REF_CURRENCY" orderClause="REF_CODE,REF_LABEL">
                 <row>
                     <field name="REF_CODE" value="CODE1"/>
@@ -170,6 +176,9 @@
             </table>
         </input>
         <etalon>
+            <comparators>
+                <comparator field="PIB" precision="0.00001"/>
+            </comparators>
             <table name="REF_CURRENCY" orderClause="REF_CODE,REF_LABEL">
                 <row inheritId="source"/>
                 <row id="duplicate" inheritId="source">

--- a/codjo-referential-server/pom.xml
+++ b/codjo-referential-server/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>codjo-referential</artifactId>
+        <groupId>net.codjo.referential</groupId>
+        <version>1.65-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>codjo-referential-server</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>net.codjo.plugin</groupId>
+            <artifactId>codjo-plugin-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.codjo.mad</groupId>
+            <artifactId>codjo-mad-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.codjo.mad</groupId>
+            <artifactId>codjo-mad-server</artifactId>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.codjo.agent</groupId>
+            <artifactId>codjo-agent</artifactId>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.codjo.test</groupId>
+            <artifactId>codjo-test-common</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.codjo.tokio</groupId>
+            <artifactId>codjo-tokio</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.codjo.database</groupId>
+            <artifactId>codjo-database-${databaseType}</artifactId>
+            <optional>true</optional>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    
+    <name>Lib &gt; Referential server</name>
+
+</project>

--- a/codjo-referential-server/pom.xml
+++ b/codjo-referential-server/pom.xml
@@ -43,13 +43,24 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>net.codjo.datagen</groupId>
+            <artifactId>codjo-datagen</artifactId>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.codjo.datagen</groupId>
+            <artifactId>codjo-datagen</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>net.codjo.database</groupId>
             <artifactId>codjo-database-${databaseType}</artifactId>
             <optional>true</optional>
             <scope>test</scope>
         </dependency>
     </dependencies>
-    
+
     <name>Lib &gt; Referential server</name>
 
 </project>

--- a/codjo-referential-server/src/main/java/server/handler/DeletePmReferentialFamilyCommand.java
+++ b/codjo-referential-server/src/main/java/server/handler/DeletePmReferentialFamilyCommand.java
@@ -1,0 +1,29 @@
+package server.handler;
+import java.sql.Connection;
+import java.sql.SQLException;
+import net.codjo.mad.server.handler.HandlerCommand;
+import net.codjo.mad.server.handler.HandlerException;
+import net.codjo.sql.server.util.SqlTransactionalExecutor;
+/**
+ *
+ */
+public class DeletePmReferentialFamilyCommand extends HandlerCommand {
+    @Override
+    public CommandResult executeQuery(CommandQuery query) throws HandlerException, SQLException {
+
+        Connection con = getContext().getConnection();
+        String sql = query.getArgumentString("familyId");
+        int familyId = Integer.parseInt(sql);
+
+        SqlTransactionalExecutor
+              .init(con)
+              .prepare("delete from PM_REF_FAMILY_REF_ASSO where FAMILY_ID = ? ")
+              .withInt(familyId)
+              .then()
+              .prepare("delete from PM_REFERENTIAL_FAMILY where FAMILY_ID = ? ")
+              .withInt(familyId)
+              .then()
+              .execute();
+        return createResult("OK");
+    }
+}

--- a/codjo-referential-server/src/main/java/server/plugin/ReferentialServerPlugin.java
+++ b/codjo-referential-server/src/main/java/server/plugin/ReferentialServerPlugin.java
@@ -1,0 +1,13 @@
+package server.plugin;
+import net.codjo.mad.server.plugin.MadServerPlugin;
+import net.codjo.plugin.server.AbstractServerPlugin;
+import server.handler.DeletePmReferentialFamilyCommand;
+/**
+ *
+ */
+public class ReferentialServerPlugin extends AbstractServerPlugin {
+
+    public ReferentialServerPlugin(MadServerPlugin madServerPlugin) {
+        madServerPlugin.getConfiguration().addHandlerCommand(DeletePmReferentialFamilyCommand.class);
+    }
+}

--- a/codjo-referential-server/src/test/java/server/handler/DeletePmReferentialFamilyCommandTest.java
+++ b/codjo-referential-server/src/test/java/server/handler/DeletePmReferentialFamilyCommandTest.java
@@ -1,7 +1,13 @@
 package server.handler;
+import java.io.File;
+import net.codjo.database.common.api.structure.SqlTable;
+import net.codjo.datagen.DatagenFixture;
 import net.codjo.mad.server.handler.HandlerCommand;
 import net.codjo.mad.server.handler.HandlerCommand.CommandResult;
 import net.codjo.mad.server.handler.HandlerCommandTestCase;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import static java.util.Collections.singletonMap;
@@ -10,12 +16,35 @@ import static net.codjo.test.common.matcher.JUnitMatchers.*;
  *
  */
 public class DeletePmReferentialFamilyCommandTest extends HandlerCommandTestCase {
+    private static final DatagenFixture DATAGEN = new DatagenFixture(DeletePmReferentialFamilyCommandTest.class,
+                                                                     "../codjo-referential-datagen/src/datagen/datagen.xml");
 
-    @Test
+
     public void test_delete() throws Exception {
         CommandResult result = assertExecuteQuery("deleteReferenceWithFamilyList",
                                                   singletonMap("familyId", "1"));
         assertThat(result.toString(), is("OK"));
+    }
+
+
+    @Override
+    public void setUp() throws Exception {
+        DATAGEN.doSetUp();
+        DATAGEN.generate();
+        super.setUp();
+        getJdbcFixture().advanced().dropAllObjects();
+
+        create("PM_REFERENTIAL_FAMILY");
+        create("PM_REF_FAMILY_REF_ASSO");
+    }
+
+
+    @Override
+    protected void tearDown() throws Exception {
+        getJdbcFixture().drop(SqlTable.table("PM_REF_FAMILY_REF_ASSO"));
+        getJdbcFixture().drop(SqlTable.table("PM_REFERENTIAL_FAMILY"));
+        DATAGEN.doTearDown();
+        super.tearDown();
     }
 
 
@@ -28,5 +57,10 @@ public class DeletePmReferentialFamilyCommandTest extends HandlerCommandTestCase
     @Override
     protected String getHandlerId() {
         return "deletePmReferentialFamily";
+    }
+
+
+    private void create(String tableName) {
+        getJdbcFixture().advanced().executeCreateTableScriptFile(new File(DATAGEN.getSqlPath(), tableName + ".tab"));
     }
 }

--- a/codjo-referential-server/src/test/java/server/handler/DeletePmReferentialFamilyCommandTest.java
+++ b/codjo-referential-server/src/test/java/server/handler/DeletePmReferentialFamilyCommandTest.java
@@ -1,0 +1,32 @@
+package server.handler;
+import net.codjo.mad.server.handler.HandlerCommand;
+import net.codjo.mad.server.handler.HandlerCommand.CommandResult;
+import net.codjo.mad.server.handler.HandlerCommandTestCase;
+import org.junit.Test;
+
+import static java.util.Collections.singletonMap;
+import static net.codjo.test.common.matcher.JUnitMatchers.*;
+/**
+ *
+ */
+public class DeletePmReferentialFamilyCommandTest extends HandlerCommandTestCase {
+
+    @Test
+    public void test_delete() throws Exception {
+        CommandResult result = assertExecuteQuery("deleteReferenceWithFamilyList",
+                                                  singletonMap("familyId", "1"));
+        assertThat(result.toString(), is("OK"));
+    }
+
+
+    @Override
+    protected HandlerCommand createHandlerCommand() {
+        return new DeletePmReferentialFamilyCommand();
+    }
+
+
+    @Override
+    protected String getHandlerId() {
+        return "deletePmReferentialFamily";
+    }
+}

--- a/codjo-referential-server/src/test/java/server/plugin/ReferentialServerPluginTest.java
+++ b/codjo-referential-server/src/test/java/server/plugin/ReferentialServerPluginTest.java
@@ -1,0 +1,33 @@
+package server.plugin;
+import net.codjo.agent.test.AgentContainerFixture;
+import net.codjo.mad.server.plugin.MadServerPluginMock;
+import net.codjo.test.common.LogString;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+/**
+ *
+ */
+public class ReferentialServerPluginTest {
+    private LogString log = new LogString();
+    private AgentContainerFixture fixture = new AgentContainerFixture();
+
+
+    @Before
+    public void setUp() throws Exception {
+        fixture.doSetUp();
+    }
+
+
+    @Test
+    public void test_handlerIsDeclared() throws Exception {
+        new ReferentialServerPlugin(new MadServerPluginMock(new LogString("madServerPlugin", log)));
+        log.assertAndClear("madServerPluginConfiguration.addHandlerCommand(DeletePmReferentialFamilyCommand)");
+    }
+
+
+    @After
+    public void tearDown() throws Exception {
+        fixture.doTearDown();
+    }
+}

--- a/codjo-referential-server/src/test/resources-filtered/database.properties
+++ b/codjo-referential-server/src/test/resources-filtered/database.properties
@@ -1,0 +1,8 @@
+database.hostname = ${databaseServer}
+database.port = ${databasePort}
+database.user = ${databaseUser}
+database.password = ${databasePassword}
+database.base = ${databaseBase}
+database.catalog = ${databaseCatalog}
+database.schema = ${databaseSchema}
+database.engine = ${databaseType}

--- a/codjo-referential-server/src/test/resources/server/handler/DeleteReferentialFamilyHandlerTest.tokio
+++ b/codjo-referential-server/src/test/resources/server/handler/DeleteReferentialFamilyHandlerTest.tokio
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!DOCTYPE Scenarii SYSTEM "http://scenarii.dtd">
+<Scenarii name="AUTOMATIC">
+    <Scenario id="deleteReferenceWithFamilyList">
+        <input>
+            <table name="PM_REFERENTIAL_FAMILY">
+                <row>
+                    <field name="FAMILY_ID" value="1"/>
+                    <field name="FAMILY_LABEL" value="Géographie"/>
+                </row>
+                <row>
+                    <field name="FAMILY_ID" value="2"/>
+                    <field name="FAMILY_LABEL" value="Monétaire"/>
+                </row>
+                <row>
+                    <field name="FAMILY_ID" value="3"/>
+                    <field name="FAMILY_LABEL" value="Finance"/>
+                </row>
+            </table>
+            <table name="PM_REF_FAMILY_REF_ASSO">
+                <row>
+                    <field name="FAMILY_ID" value="1"/>
+                    <field name="REFERENTIAL_ID" value="CurrencyList"/>
+                </row>
+                <row>
+                    <field name="FAMILY_ID" value="1"/>
+                    <field name="REFERENTIAL_ID" value="CountryList"/>
+                </row>
+                <row>
+                    <field name="FAMILY_ID" value="1"/>
+                    <field name="REFERENTIAL_ID" value="BidonList"/>
+                </row>
+                <row>
+                    <field name="FAMILY_ID" value="2"/>
+                    <field name="REFERENTIAL_ID" value="CurrencyList"/>
+                </row>
+                <row>
+                    <field name="FAMILY_ID" value="3"/>
+                    <field name="REFERENTIAL_ID" value="ValFrequencyList"/>
+                </row>
+            </table>
+        </input>
+        <etalon>
+            <table name="PM_REFERENTIAL_FAMILY">
+                <row>
+                    <field name="FAMILY_ID" value="2"/>
+                    <field name="FAMILY_LABEL" value="Monétaire"/>
+                </row>
+                <row>
+                    <field name="FAMILY_ID" value="3"/>
+                    <field name="FAMILY_LABEL" value="Finance"/>
+                </row>
+            </table>
+            <table name="PM_REF_FAMILY_REF_ASSO">
+                <row>
+                    <field name="FAMILY_ID" value="2"/>
+                    <field name="REFERENTIAL_ID" value="CurrencyList"/>
+                </row>
+                <row>
+                    <field name="FAMILY_ID" value="3"/>
+                    <field name="REFERENTIAL_ID" value="ValFrequencyList"/>
+                </row>
+            </table>
+        </etalon>
+
+    </Scenario>
+</Scenarii>

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,11 @@
             </dependency>
             <dependency>
                 <groupId>net.codjo.referential</groupId>
+                <artifactId>codjo-referential-server</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.codjo.referential</groupId>
                 <artifactId>codjo-referential-datagen</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -54,6 +59,7 @@
     <modules>
         <module>codjo-referential-datagen</module>
         <module>codjo-referential-gui</module>
+        <module>codjo-referential-server</module>
         <module>codjo-referential-release-test</module>
         <module>codjo-referential-gui-addon</module>
     </modules>


### PR DESCRIPTION
## Oracle Support - Update deleteHandler to be database agnostic
### Context

The library declares a sybase specific `handler-delete` in its datagen configuration file. 
### Description

The  `handler-delete` definition specifies a sql instruction wich is composed of two delete statements. This can't work with Oracle jdbc driver.

We moved this code to a `handler-command` to execute the two delete statements through java code, and as a matter of fact, we added a new `codjo-referential-server` module in `codjo-referential`. 
This implies a new dependency on for the projects that want to use this delete handler.
## Upgrade of mockito
### Context

Need the use of `Mockito.doCallRealMethod` (start to be present in version 1.8 of `mockito`).
### Description

The version has been upgraded to the last version: `1.9.0`.
This implies the replacement in `DepedencyTest` tests of: 
`-> org.mockito.internal.progress`
by:
`-> org.mockito.stubbing`
